### PR TITLE
Changed [callProc] args type. It accepts only primitive values.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,30 +1,31 @@
+type primitiveTypes = string | number | undefined | boolean | bigint | null | symbol;
 interface Mp {
-	events: EventMpPool;
+    events: EventMpPool;
 
-	trigger(name: string, ...args: any[]): void;
-	invoke(name: string, ...args: any[]): void;
+    trigger(name: string, ...args: any[]): void;
+    invoke(name: string, ...args: any[]): void;
 }
 
 interface EventMpPool {
-	/**
-	 * This function calls registered Remote Prodecure Call (RPC) from browser to client-side and expects a callback.
-	 *
-	 * @param eventName Client name event you want to call.
-	 * @param args Data you want to send to client.
-	 * @returns Returns a promise
-	 *
-	 * @example
-	 * ```js
-	 * mp.events.callProc('test_proc', 'test');
-	 * ```
-	 *
-	 *
-	 */
-	callProc<T, K>(eventName: string, args: K): Promise<T>;
+    /**
+     * This function calls registered Remote Prodecure Call (RPC) from browser to client-side and expects a callback.
+     *
+     * @param eventName Client name event you want to call.
+     * @param args Data you want to send to client, it accepts only primitive-values.
+     * @returns Returns a promise
+     *
+     * @example
+     * ```js
+     * mp.events.callProc('test_proc', 'test');
+     * ```
+     *
+     *
+     */
+    callProc<T>(eventName: string, args: primitiveTypes): Promise<T>;
 }
 
 interface Window {
-	mp: Mp;
+    mp: Mp;
 }
 
 declare var mp: Mp;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type primitiveTypes = string | number | undefined | boolean | bigint | null | symbol;
+type PrimitiveTypes = string | number | undefined | boolean | bigint | null | symbol;
 interface Mp {
     events: EventMpPool;
 
@@ -21,7 +21,7 @@ interface EventMpPool {
      *
      *
      */
-    callProc<T>(eventName: string, args: primitiveTypes): Promise<T>;
+    callProc<T>(eventName: string, args: PrimitiveTypes): Promise<T>;
 }
 
 interface Window {


### PR DESCRIPTION
It seems that callProc accepts only primitive values.
JSON.stringify is required to pass objects from CEF to client.