### PR TITLE
Add macOS .DS_Store file to .gitignore (clean up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+#macOS files
+.DS_Store


### PR DESCRIPTION
If someone edits the projects on a macOS device, they'll accidentally push the annoying .DS_Store files that macOS generates to the repo. Updated the gitignore file to exclude those.