### PR TITLE
Moved newWeaponObject from ObjectMp to ObjectMpPool

### DIFF
--- a/packages/client/index.d.ts
+++ b/packages/client/index.d.ts
@@ -3112,11 +3112,6 @@ declare interface ObjectMp extends EntityMp {
 	): void;
 	setTargettable(targettable: boolean): void;
 	slide(toX: number, toY: number, toZ: number, speedX: number, speedY: number, speedZ: number, collision: boolean): boolean;
-	newWeaponObject(
-		weaponHash: number,
-		position: Vector3,
-		options?: { ammo?: number; scale?: number; showWorldObject?: boolean; rotation?: Vector3 }
-	): void;
 	getAllByHash(hash: number): void;
 }
 
@@ -3132,6 +3127,11 @@ declare interface ObjectMpPool extends EntityMpPool<ObjectMp> {
 	): ObjectMp;
 
 	newWeak(handle: number): ObjectMp;
+	newWeaponObject(
+		weaponHash: number,
+		position: Vector3,
+		options?: { ammo?: number; scale?: number; showWorldObject?: boolean; rotation?: Vector3 }
+	): ObjectMp;
 }
 
 declare interface Mp {


### PR DESCRIPTION
The method newWeaponObject is currently added in the ObjectMp scope, which is wrong. It's supposed to be placed inside the ObjectMpPool (mp.objects.newWeaponObject(...))

Also changed the return type of newWeaponObject from void to ObjectMp