### PR TITLE
Add missing EventMpPool methods that was added to CEF in 1.1

### DIFF
--- a/packages/cef/index.d.ts
+++ b/packages/cef/index.d.ts
@@ -29,6 +29,9 @@ interface EventMpPool {
 	 */
 	add(name: string, ...args: any[]): void;
 	add(names: { [name: string]: (...args: any[]) => void }): void;
+	remove(name: string): void;
+	call(name: string): void;
+	reset(): void;
 }
 
 interface Window {

--- a/packages/cef/index.d.ts
+++ b/packages/cef/index.d.ts
@@ -31,7 +31,6 @@ interface EventMpPool {
 	add(names: { [name: string]: (...args: any[]) => void }): void;
 	remove(name: string): void;
 	call(name: string): void;
-	reset(): void;
 }
 
 interface Window {


### PR DESCRIPTION
> In CEF you're not allowed to register any events. You can only call the functions that are registered in your CEF.
In 1.1 version:
Added: CEF: mp.events.add(string eventName, function handler)
Added: CEF: mp.events.reset()
Added: CEF: mp.events.remove(string eventName)
Added: CEF: mp.events.call(string eventName) (‎pseudonym ‎к mp.trigger)
Added: Client-side: Browser.call(eventName, arguments...)
https://wiki.rage.mp/index.php?title=Getting_Started_with_Events#Using_events
